### PR TITLE
Fix compiling with musl

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #include <math.h>
 #include <strings.h>
 #include <ctype.h>
+#include <libgen.h>
 
 
 static const struct deviceId* findDeviceByName(const char *name) 


### PR DESCRIPTION
This fixes 
`error: 'basename' was not declared in this scope` 
when compiling with musl (eg. openwrt)