### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/lib/HIDDCDCUSB.cpp
+++ b/src/lib/HIDDCDCUSB.cpp
@@ -9,6 +9,7 @@
 #include "HIDDCDCUSB.h"
 #include "util.h"
 #include <math.h>
+#include <unistd.h>
 
 #define A_SLEEP 5
 #define A_TIMEOUT 3000

--- a/src/lib/HIDInterface.cpp
+++ b/src/lib/HIDInterface.cpp
@@ -10,6 +10,7 @@
 #include <strings.h>
 #include <stdarg.h>
 #include <ctype.h>
+#include <stdlib.h>
 
 #include "HIDInterface.h"
 #include "HArray.h"

--- a/src/lib/HIDNUCUPS.cpp
+++ b/src/lib/HIDNUCUPS.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <math.h>
+#include <unistd.h>
 
 #include "HIDNUCUPS.h"
 

--- a/src/lib/HIDNUCUPS.h
+++ b/src/lib/HIDNUCUPS.h
@@ -1,5 +1,5 @@
 #ifndef _HIDNUCUPS_H_
-#define _HIDINUCUPS_H_
+#define _HIDNUCUPS_H_
 
 #include "usbhid.h"
 #include "util.h"

--- a/src/lib/HIDOpenUPS.cpp
+++ b/src/lib/HIDOpenUPS.cpp
@@ -7,6 +7,7 @@
 
 #include "util.h"
 #include "HIDOpenUPS.h"
+#include <unistd.h>
 
 #include <math.h>
 

--- a/src/lib/HIDOpenUPS2.cpp
+++ b/src/lib/HIDOpenUPS2.cpp
@@ -7,6 +7,7 @@
 
 #include "util.h"
 #include "HIDOpenUPS2.h"
+#include <unistd.h>
 
 #include <math.h>
 

--- a/src/lib/usbhid.cpp
+++ b/src/lib/usbhid.cpp
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #undef DEBUG_RECV
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@
 #include <ctype.h>
 #include <libgen.h>
 #include <cerrno>
+#include <unistd.h>
 
 
 static const struct deviceId* findDeviceByName(const char *name) 


### PR DESCRIPTION
* This PR fixes the build for FreeBSD
* `usleep(3)` requires `#include <unistd.h>`
* `malloc(3)` requires `#include <stdlib.h>`
* It also fixes a typo in one include guard